### PR TITLE
fix: modules should not pin max versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.26"
+      version = ">= 3.26"
     }
   }
-  required_version = "~> 0.13.6"
+  required_version = ">= 0.13.6"
 }


### PR DESCRIPTION
https://www.terraform.io/docs/language/providers/requirements.html#best-practices-for-provider-versions